### PR TITLE
feat: random map generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 GO ?=go
+GO_TEST ?=${GO}
 GO_SERVER ?=${GO}
 GO_CLIENT ?=${GO}
 
@@ -16,7 +17,7 @@ build_server:
 	GOOS=linux CGO_ENABLED=0 go build -o bin/linux/server server/main.go
 
 test:
-	go test -v ./...
+	${GO_TEST} test -v ./...
 
 lint:
 	golangci-lint run --tests=false ./...

--- a/server/corners/board.go
+++ b/server/corners/board.go
@@ -35,6 +35,19 @@ type Map struct {
 }
 
 func loadMap(name string) Map {
+	if name == "random" {
+		return GenerateRandomMap(Options{
+			startingPoints: [][2]int{
+				{02, 02},
+				{13, 13},
+				{13, 02},
+				{02, 13},
+			},
+			numberOfGenerators: 0,
+			numberOfWalls:      0,
+		})
+	}
+
 	m, err := os.ReadFile(name + ".json")
 	if err != nil {
 		panic(err)

--- a/server/corners/board.go
+++ b/server/corners/board.go
@@ -18,18 +18,20 @@ type Board struct {
 	done   chan bool
 }
 
+type MapOverride struct {
+	XR        []int
+	YR        []int
+	X         int
+	Y         int
+	Generator bool
+	Armies    int
+}
+
 type Map struct {
 	Name           string
 	Size           int
 	StartingPoints [][2]int
-	Overrides      []struct {
-		XR        []int
-		YR        []int
-		X         int
-		Y         int
-		Generator bool
-		Armies    int
-	}
+	Overrides      []MapOverride
 }
 
 func loadMap(name string) Map {

--- a/server/corners/random.go
+++ b/server/corners/random.go
@@ -1,0 +1,168 @@
+package corners
+
+import (
+	"math/rand"
+	"time"
+)
+
+type Point struct {
+	x, y int
+}
+
+func (p *Point) Values() (int, int) {
+	return p.x, p.y
+}
+
+func (p *Point) Offset(x, y int) Point {
+	return Point{p.x + x, p.y + y}
+}
+
+type tileTracker struct {
+	size int
+	grid [][]string
+}
+
+func newTileTracker(size int) tileTracker {
+	tt := tileTracker{
+		size: size,
+	}
+
+	tt.grid = make([][]string, tt.size)
+	for x := range tt.grid {
+		tt.grid[x] = make([]string, tt.size)
+		for y := range tt.grid[x] {
+			tt.grid[x][y] = "free"
+		}
+	}
+
+	return tt
+}
+
+func (tt *tileTracker) findAllFreePoints() []Point {
+	var points []Point
+
+	for x := range tt.grid {
+		for y := range tt.grid[x] {
+			if tt.grid[x][y] == "free" {
+				points = append(points, Point{x, y})
+			}
+		}
+	}
+
+	return points
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func (tt *tileTracker) pickRandomFreePoint() Point {
+	freePoints := tt.findAllFreePoints()
+
+	// todo: decide how to handle this gracefully
+	if len(freePoints) == 0 {
+		panic("there are no more free points!")
+	}
+
+	return freePoints[rand.Intn(len(freePoints))]
+}
+
+func (tt *tileTracker) getAt(point Point) string {
+	return tt.grid[point.x][point.y]
+}
+
+func (tt *tileTracker) setAt(point Point, value string) {
+	if point.x < 0 || point.y < 0 {
+		return
+	}
+	if point.x >= tt.size || point.y >= tt.size {
+		return
+	}
+
+	tt.grid[point.x][point.y] = value
+}
+
+func (tt *tileTracker) occupyRandomPoint(object string) Point {
+	point := tt.pickRandomFreePoint()
+
+	tt.occupyPoint(point, object)
+
+	return point
+}
+
+func (tt *tileTracker) occupyPoint(point Point, object string) {
+	// todo: decide how to handle this gracefully
+	if tt.getAt(point) != "free" {
+		panic("space is not free!")
+	}
+
+	tt.setAt(point, "occupied")
+
+	// generators cannot be right next to each other
+	if object == "generator" {
+		tt.setAt(point.Offset(-1, -1), "claimed")
+		tt.setAt(point.Offset(+0, -1), "claimed")
+		tt.setAt(point.Offset(+1, -1), "claimed")
+		tt.setAt(point.Offset(-1, +0), "claimed")
+
+		tt.setAt(point.Offset(+1, +0), "claimed")
+		tt.setAt(point.Offset(-1, +1), "claimed")
+		tt.setAt(point.Offset(+0, +1), "claimed")
+		tt.setAt(point.Offset(+1, +1), "claimed")
+	}
+}
+
+type Options struct {
+	startingPoints     [][2]int
+	numberOfGenerators int
+	numberOfWalls      int
+}
+
+func GenerateRandomMap(options Options) Map {
+	tt := newTileTracker(16)
+	ma := Map{
+		Name:           "random",
+		Size:           16,
+		StartingPoints: options.startingPoints,
+		Overrides:      []MapOverride{},
+	}
+
+	for _, point := range ma.StartingPoints {
+		x, y := point[0], point[1]
+
+		tt.occupyPoint(Point{x, y}, "generator")
+
+		ma.Overrides = append(ma.Overrides, MapOverride{
+			X:         x,
+			Y:         y,
+			Generator: true,
+			Armies:    10,
+		})
+	}
+
+	for i := 0; i < options.numberOfGenerators; i++ {
+		point := tt.occupyRandomPoint("generator")
+		x, y := point.Values()
+
+		ma.Overrides = append(ma.Overrides, MapOverride{
+			X:         x,
+			Y:         y,
+			Generator: true,
+			Armies:    10,
+		})
+	}
+
+	for i := 0; i < options.numberOfWalls; i++ {
+		point := tt.occupyRandomPoint("wall")
+		x, y := point.Values()
+
+		ma.Overrides = append(ma.Overrides, MapOverride{
+			X:         x,
+			Y:         y,
+			Generator: false,
+			Armies:    100,
+		})
+	}
+
+	return ma
+}

--- a/server/corners/random_test.go
+++ b/server/corners/random_test.go
@@ -1,0 +1,118 @@
+package corners
+
+import (
+	"testing"
+)
+
+func isStartingPointGenerator(override MapOverride, startingPoint [2]int) bool {
+	return override.Generator &&
+		override.X == startingPoint[0] &&
+		override.Y == startingPoint[1]
+}
+
+func TestStartingPointsHaveGenerators(t *testing.T) {
+	startingPoints := [][2]int{
+		{02, 01},
+		{13, 13},
+		{15, 03},
+	}
+
+	generatedMap := GenerateRandomMap(Options{
+		startingPoints:     startingPoints,
+		numberOfGenerators: 0,
+		numberOfWalls:      0,
+	})
+
+	var missing [][2]int
+
+	for _, startingPoint := range startingPoints {
+		found := false
+
+		for _, override := range generatedMap.Overrides {
+			// discount generators created for starting points
+			if isStartingPointGenerator(override, startingPoint) {
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			missing = append(missing, startingPoint)
+		}
+	}
+
+	if len(missing) > 0 {
+		t.Errorf("%d starting points don't have a generator", len(missing))
+	}
+}
+
+func expectExtrasCount(t *testing.T, expectedGenerators, expectedWalls int) {
+	startingPoints := [][2]int{
+		{02, 01},
+		{13, 13},
+		{15, 03},
+	}
+
+	generatedMap := GenerateRandomMap(Options{
+		startingPoints:     startingPoints,
+		numberOfGenerators: expectedGenerators,
+		numberOfWalls:      expectedWalls,
+	})
+
+	extraGeneratorsCount := 0
+	extraWallsCount := 0
+
+	for _, override := range generatedMap.Overrides {
+		extra := true
+
+		for _, startingPoint := range startingPoints {
+			// discount generators created for starting points
+			if isStartingPointGenerator(override, startingPoint) {
+				extra = false
+
+				break
+			}
+		}
+
+		if extra {
+			if override.Generator {
+				extraGeneratorsCount += 1
+			} else {
+				extraWallsCount += 1
+			}
+		}
+	}
+
+	if extraGeneratorsCount != expectedGenerators {
+		t.Errorf(
+			"Found %d extra generators but expected %d",
+			extraGeneratorsCount,
+			expectedGenerators,
+		)
+	}
+
+	if extraWallsCount != expectedWalls {
+		t.Errorf(
+			"Found %d extra walls but expected %d",
+			extraWallsCount,
+			expectedWalls,
+		)
+	}
+}
+
+func TestNoExtraGeneratorsOrWalls(t *testing.T) {
+	expectExtrasCount(t, 0, 0)
+}
+
+func TestGeneratesExtraGeneratorsButNoWalls(t *testing.T) {
+	expectExtrasCount(t, 10, 10)
+}
+
+func TestGeneratesNoExtraGeneratorsButExtraWalls(t *testing.T) {
+	expectExtrasCount(t, 0, 10)
+}
+
+func TestGeneratesExtraGeneratorsAndWalls(t *testing.T) {
+	expectExtrasCount(t, 10, 10)
+}


### PR DESCRIPTION
This works by having an internal class (?) that holds a small version of the whole game grid; spaces on this grid can be in one of three states: `free`, `claimed`, or `occupied`.

Generation occurs by collecting a list of all the points that are marked as `free` and then picking one at random to occupy with an object (either `generator` or `wall`) - occupying a point changes its state to `occupied`, and if the occupying "object" (because "type" is a reserved word in Go) is a `generator` then we claim the surrounding points by marking them as `claimed` to prevent another object from being placed immediately next to that `generator`.

(The actual use of `claimed` is at this point mainly aesthetic since our check is "is `free`", but I think it could be useful in the future) 

-----

I'm eh about the tests - they cover some stuff, and they're ok but man Go really makes me miss the friendly matchers we have in the likes of Jest...

Ideally I'd have some tests for the "generators cannot be next to each other" thing, but that'd involve messing with the error handling which I've currently got just panicking 🤷 

-----

Also, I've started using the `Point` struct we talked about, but will pull it out into its own thing in a follow-up.